### PR TITLE
ci: expand test matrix to include macOS 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -37,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"


### PR DESCRIPTION
This PR updates the GitHub Actions workflow for tests to include macOS 14, ensuring compatibility across a wider range of operating systems.

- Added `macos-14` to the OS matrix in `.github/workflows/tests.yml`
- Standardized quotation marks for the `path` parameter in the upload-artifact step

`CI GitHubActions macOS compatibility testing`